### PR TITLE
NCSD-813 Add dacpac deployment

### DIFF
--- a/src/changefeed/Dfc.DiscoverSkillsAndCareers.ChangedFeed.Db/Dfc.DiscoverSkillsAndCareers.ChangedFeed.Db.sqlproj
+++ b/src/changefeed/Dfc.DiscoverSkillsAndCareers.ChangedFeed.Db/Dfc.DiscoverSkillsAndCareers.ChangedFeed.Db.sqlproj
@@ -8,7 +8,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectVersion>4.1</ProjectVersion>
     <ProjectGuid>{39868781-db54-4d73-85a1-dda9ddd9bd0e}</ProjectGuid>
-    <DSP>Microsoft.Data.Tools.Schema.Sql.Sql130DatabaseSchemaProvider</DSP>
+    <DSP>Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider</DSP>
     <OutputType>Database</OutputType>
     <RootPath>
     </RootPath>
@@ -25,6 +25,7 @@
     <TargetDatabaseSet>True</TargetDatabaseSet>
     <DefaultCollation>Latin1_General_CI_AS</DefaultCollation>
     <DefaultFilegroup>PRIMARY</DefaultFilegroup>
+    <IsEncryptionOn>True</IsEncryptionOn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>


### PR DESCRIPTION
The current provider version is not compatible with azure db:

```
 <DSP>Microsoft.Data.Tools.Schema.Sql.Sql130DatabaseSchemaProvider</DSP>
```

This causes deployments to fail with the following error:

```
2019-06-04T15:28:07.2082359Z ##[error]*** An error occurred during deployment plan generation. Deployment cannot continue.
2019-06-04T15:28:07.2177133Z ##[error]A project which specifies SQL Server 2016 as the target platform cannot be published to Microsoft Azure SQL Database v12.
```

This PR changes the provider to the following which will fix deployments:

```
<DSP>Microsoft.Data.Tools.Schema.Sql.SqlAzureV12DatabaseSchemaProvider</DSP>
```

and also enables encryption:

```
<IsEncryptionOn>True</IsEncryptionOn>
```

@colinbull As this is a change to work you have committed i've requested your approval too.
