### PR TITLE
Fix path to metric alerts on template

### DIFF
--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -38,7 +38,7 @@
         },
         "AspInstances": {
             "type": "int",
-            "defaultValue": 1
+            "defaultValue": 2
         },
         "AspTier": {
             "type": "string"
@@ -1099,10 +1099,10 @@
             "type": "Microsoft.Resources/deployments",
             "properties": {
                 "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'metric-alerts.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
+              "templateLink": {
+                "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
+                "contentVersion": "1.0.0.0"
+              },
                 "parameters": {
                     "enabled": {
                         "value": "[variables('EnableAlertsAndMetrics')]"


### PR DESCRIPTION
Release pipeline template updates
- path to metric alerts fix.
- asp instance defaulted to 2 instances for resilience and to catch issues early on in dev & test environments.