### PR TITLE
Update privacy and cookies URL to privacy-and-cookies

### DIFF
--- a/src/Dfc.DiscoverSkillsAndCareers.WebApp/ViewsDev/partials/_base.njk
+++ b/src/Dfc.DiscoverSkillsAndCareers.WebApp/ViewsDev/partials/_base.njk
@@ -130,7 +130,7 @@
             text: "Help"
           },
           {
-            href: "https://nationalcareers.service.gov.uk/help/cookies",
+            href: "https://nationalcareers.service.gov.uk/help/privacy-and-cookies",
             text: "Privacy and Cookies"
           }, 
 		  {


### PR DESCRIPTION
Updated privacy and cookies url to 
https://nationalcareers.service.gov.uk/help/privacy-and-cookies