### PR TITLE
DYSAC DFC- Cookie - Green bar styling fix

### DIFF
--- a/src/Dfc.DiscoverSkillsAndCareers.WebApp/src/scss/main.scss
+++ b/src/Dfc.DiscoverSkillsAndCareers.WebApp/src/scss/main.scss
@@ -62,8 +62,10 @@ nav {
 // Change to header to change colour of blue border underneath header to green.
 .govuk-header__container {
   border-bottom: 10px solid $app-turquoise;
+  margin-bottom: -10px;
   @include govuk-media-query(desktop) {
-    padding-top: 7px;
+    padding-top: 10px;
+    padding-bottom: 1px;
   }
 }
 
@@ -75,7 +77,6 @@ nav {
 }
 
 .govuk-header__navigation {
-  
   @include govuk-media-query(desktop) {
     margin: 0 0 4px;
   }


### PR DESCRIPTION
1.  Added negative margin, pushing the green bar to the bottom of Navigation, outside black bar
2. Added extra padding to increase the gap between National Career Service logo and top of the black container
